### PR TITLE
peto/support full lifecycle rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,12 +61,6 @@ module "test_bucket" {
     * This info is needed so Infra staff can find Point Of Contact for the bucket.
     * Value `responsible_people` please fill with email of slack handle. Not optional, but can be empty string if there is no direct responsible person.
     * Value `communication_slack_channel` Name of primary Slack channel for communication Examples: #platform-infra
-<br /> 
-  
-* `expiration_rule` object(bool, number)
-    * This defines a object [lifecycle](https://cloud.google.com/storage/docs/lifecycle) action with `Delete` action set to value of `days`
-    * Is is strongly encouraged to define a expiration_rule for your bucket, please consider usage cases for data in your bucket and set accordingly.
-    * If your usage case requires it, it's possible to not set a expiration_rule by setting `delete = false`
 <br />
 
 * `members_object_viewer` `members_object_creator` `members_object_admin` `members_storage_admin` list(string)
@@ -86,21 +80,21 @@ module "test_bucket" {
 ```
 <br />
 
-* `conversion_rule` list(map(string))
-    * Use these to change the [storage class](https://cloud.google.com/storage/docs/storage-classes) of an object when the object meets conditions specified in the lifecycle rule.
-    * This defines a object [lifecycle](https://cloud.google.com/storage/docs/lifecycle) action with `SetStorageClass` with `Age` set to value of `days`
-    * Generally we use these downgrade storage class of objects in order to reduce costs.
+* `lifecycle_rules` set(object({ action = map(string) condition = map(string) }))
+    * Use these when you want to delete old objects or change Storage Class.
+    * We generally use these to move objects to a cost-efficient storage when data is no longer accessed on daily basis.
+    * See [Lifecycle Actions](https://cloud.google.com/storage/docs/lifecycle#actions) and [Lifecycle Conditions](https://cloud.google.com/storage/docs/lifecycle#conditions) on what can be defined here.
   
   
-```hcl-terraform
-  conversion_rule = [
+```terraform
+  lifecycle_rules = [
     {
-      storage_class = "NEARLINE"
-      days          = 90
-    },
-    {
-      storage_class = "ARCHIVE"
-      days          = 365
+      action {
+        type = "Delete"
+      }
+      condition {
+        age = 50 # in days
+      }
     }
   ]
 ```

--- a/README.md
+++ b/README.md
@@ -21,12 +21,6 @@ module "test_bucket" {
     env     = "sandbox" # can be sandbox of production
     public  = "no"      # yes or no
   }
-
-  expiration_rule = {   # expiration policy in days
-    delete  = true
-    days    = 365
-  }
-
 }
 ```
 
@@ -89,10 +83,10 @@ module "test_bucket" {
 ```terraform
   lifecycle_rules = [
     {
-      action {
+      action = {
         type = "Delete"
       }
-      condition {
+      condition = {
         age = 50 # in days
       }
     }
@@ -140,20 +134,33 @@ module "test_bucket2" {
   members_object_creator = [
     "serviceAccount:something@platform-sandbox-6b6f7700.iam.gserviceaccount.com",
   ]
-
-  expiration_rule = {
-    delete  = true
-    days    = 730
-  }
-
-  conversion_rule = [
+  
+  lifecycle_rules = [
     {
-      storage_class = "NEARLINE"
-      days          = 90
+      action = {
+        type          = "SetStorageClass"
+        storage_class = "NEARLINE"
+      }
+      condition = {
+        age = 90 # in days
+      }
     },
     {
-      storage_class = "ARCHIVE"
-      days          = 365
+      action = {
+        type          = "SetStorageClass"
+        storage_class = "ARCHIVE"
+      }
+      condition = {
+        age = 180
+      }
+    },
+    {
+      action = {
+        type = "Delete"
+      }
+      condition = {
+        age = 365
+      }
     }
   ]
   
@@ -161,7 +168,6 @@ module "test_bucket2" {
     main_page_suffix = "index.html"
     not_found_page = null
   }
-
 }
 ```
 ## Release notes
@@ -170,4 +176,8 @@ module "test_bucket2" {
 Initial release
 
 ### 1.0.4
-Add support for versioning
+Add support for versioning[]
+
+### 2.0
+
+Breaking change: `expiration_rule` and `conversion_rule` were replaced by `lifecycle_rules`

--- a/examples/simple/main.tf
+++ b/examples/simple/main.tf
@@ -1,0 +1,26 @@
+module "simple" {
+  source = "../.."
+
+  bucket_name = "peto-sandbox-simple-bucket"
+  location = "EU"
+
+  owner_info = {
+    responsible_people          = "peter.malina@kiwi.com"
+    communication_slack_channel = "#plz-platform-infra"
+  }
+
+  labels = {
+    tribe   = "platform"
+    env     = "sandbox"
+    public  = "no"
+  }
+
+  lifecycle_rules = [{
+    action = {
+      type = "Delete"
+    }
+    condition = {
+      days_since_custom_time = 50
+    }
+  }]
+}

--- a/interface.tf
+++ b/interface.tf
@@ -86,25 +86,13 @@ variable "randomise" {
   default = true
 }
 
-variable "expiration_rule" {
-  type = object({
-    delete = bool
-    days   = number
-    }
-  )
-  default = {
-    delete = true
-    days   = 0
-  }
-  validation {
-    condition     = var.expiration_rule.delete == false || var.expiration_rule.days > 0
-    error_message = "Set days > 0, or if you have a valid usage case, set delete to: false ."
-  }
-}
-
-variable "conversion_rule" {
-  type    = list(map(string))
-  default = []
+variable "lifecycle_rules" {
+  type = set(object({
+    action    = map(string)
+    condition = map(string)
+  }))
+  description = "https://www.terraform.io/docs/providers/google/r/storage_bucket.html#lifecycle_rule"
+  default     = []
 }
 
 variable "website" {

--- a/main.tf
+++ b/main.tf
@@ -29,26 +29,19 @@ resource "google_storage_bucket" "bucket" {
   }
 
   dynamic "lifecycle_rule" {
-    for_each = var.expiration_rule.delete == true ? [1] : []
+    for_each = var.lifecycle_rules
     content {
       action {
-        type = "Delete"
+        type          = lifecycle_rule.value.action.type
+        storage_class = lookup(lifecycle_rule.value.action, "storage_class", null)
       }
       condition {
-        age = var.expiration_rule.days
-      }
-    }
-  }
-
-  dynamic "lifecycle_rule" {
-    for_each = [for item in var.conversion_rule : item]
-    content {
-      action {
-        type          = "SetStorageClass"
-        storage_class = lookup(lifecycle_rule.value, "storage_class", null)
-      }
-      condition {
-        age = lookup(lifecycle_rule.value, "days", null)
+        age                    = lookup(lifecycle_rule.value.condition, "age", null)
+        created_before         = lookup(lifecycle_rule.value.condition, "created_before", null)
+        with_state             = lookup(lifecycle_rule.value.condition, "with_state", lookup(lifecycle_rule.value.condition, "is_live", false) ? "LIVE" : null)
+        matches_storage_class  = contains(keys(lifecycle_rule.value.condition), "matches_storage_class") ? split(",", lifecycle_rule.value.condition["matches_storage_class"]) : null
+        num_newer_versions     = lookup(lifecycle_rule.value.condition, "num_newer_versions", null)
+        days_since_custom_time = lookup(lifecycle_rule.value.condition, "days_since_custom_time", null)
       }
     }
   }
@@ -59,7 +52,6 @@ resource "google_storage_bucket" "bucket" {
       enabled = true
     }
   }
-
 }
 
 resource "google_storage_bucket_iam_binding" "storage_admin" {


### PR DESCRIPTION
This adds a full lifecycle support to the bucket while removing the previously used rules.