### PR TITLE
chore(destroy-prevention): set force destroy to false

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -28,6 +28,8 @@ resource "google_storage_bucket" "bucket" {
     }
   }
 
+  force_destroy = false
+
   lifecycle {
     prevent_destroy = true
   }


### PR DESCRIPTION
Lifecycle "prevent destroy = true" is ignored when you remove code and run `terraform apply` (it's effective only with `terraform destroy` command).

We want to prevent bucket destruction as much as possible, so we are setting `force-destroy` to `false`. So it will not be possible to destroy a bucket with some objects inside.